### PR TITLE
Request page with Google-AMPHTML user-agent

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -34,7 +34,12 @@ module.exports.validate = (event, context, callback) => {
     sendError('No URL provided', null, callback)
   }
 
-  const requestPromise = request(docUrl).catch(error => {
+  const requestPromise = request({
+    uri: docUrl,
+    headers: {
+      'User-Agent': 'Google-AMPHTML'
+    }
+  }).catch(error => {
     sendError(error, docUrl, callback)
   })
   const validatorPromise = amphtmlValidator.getInstance()


### PR DESCRIPTION
Some firewalls will block empty user-agent requests, and this PR adds user-agent similar to Google's one.