### PR TITLE
Update to Node.js 14 runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "14"
 before_install:
   - npm install npm@latest -g
 install:

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: amp-validator
 
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs14.x
   stage: v1
   region: us-east-1
 


### PR DESCRIPTION
As [Node.js 10 is going EOL](https://twitter.com/nodejs/status/1388116425361874945), AWS Lambda also deprecates its support for Node.js 10. So let's upgrade to Node.js 14.